### PR TITLE
Ansible v2 compatible

### DIFF
--- a/callback/changes.py
+++ b/callback/changes.py
@@ -2,7 +2,10 @@ import json
 import os
 import errno
 
-from ansible.plugins.callback import CallbackBase
+try:
+    from ansible.plugins.callback import CallbackBase
+except ImportError:
+    CallbackBase = object
 
 class CallbackModule(CallbackBase):
     """

--- a/callback/changes.py
+++ b/callback/changes.py
@@ -5,6 +5,7 @@ import errno
 try:
     from ansible.plugins.callback import CallbackBase
 except ImportError:
+    print "Fallback to Ansible 1.x compatibility"
     CallbackBase = object
 
 class CallbackModule(CallbackBase):

--- a/callback/changes.py
+++ b/callback/changes.py
@@ -2,20 +2,31 @@ import json
 import os
 import errno
 
-class CallbackModule(object):
+from ansible.plugins.callback import CallbackBase
+
+class CallbackModule(CallbackBase):
+    """
+    This Ansible callback plugin flags idempotency tests failures
+    """
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'notification'
+    CALLBACK_NAME = 'changes'
+    CALLBACK_NEEDS_WHITELIST = True
+
     def __init__(self):
+        super(CallbackModule, self).__init__()
+
         self.change_file = os.getenv('PLUGIN_CHANGES_FILE', "/tmp/kitchen_ansible_callback/changes")
         change_dir = os.path.dirname(self.change_file)
         if not os.path.exists(change_dir):
             os.makedirs(change_dir)
-        
+
         try:
             os.remove(self.change_file)
         except OSError as e: # this would be "except OSError, e:" before Python 2.6
             if e.errno != errno.ENOENT: # errno.ENOENT = no such file or directory
                 raise # re-raise exception if a different error occured
 
-        
 
     def write_changed_to_file(self, host, res, name=None):
         changed_data = dict()

--- a/kitchen-ansiblepush.gemspec
+++ b/kitchen-ansiblepush.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.licenses          = ['MIT']
   gem.homepage          = "https://github.com/ahelal/kitchen-ansiblepush"
   gem.summary           = "ansible provisioner for test-kitchen"
-  candidates            = Dir.glob("{lib}/**/*") + ['README.md', 'kitchen-ansiblepush.gemspec', 'callback/changes_callback.py']
+  candidates            = Dir.glob("{lib}/**/*") + ['README.md', 'kitchen-ansiblepush.gemspec', 'callback/changes.py']
   gem.files             = candidates.sort
   gem.platform          = Gem::Platform::RUBY
   gem.require_paths     = ['lib']

--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module AnsiblePush
-    VERSION = "0.3.8"
+    VERSION = "0.3.9"
   end
 end

--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module AnsiblePush
-    VERSION = "0.3.7"
+    VERSION = "0.3.7-1"
   end
 end


### PR DESCRIPTION
Hi!

I got Ansible 2.x working without breaking backwards compatibility to 1.x
Had to rename the callback filename from callback/changes_callback.py to callback/changes.py and still needs whitelisting in ansible.cfg, section defaults:

callback_whitelist = changes

Please let me know if you need any help or something changed

Regards!
  --Ariel
