### PR TITLE
Fixes #16: Add flag to enable use of full instance name as the machine name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ provisioner         :
     vault_password_file : "/..../file"
     host_key_checking   : false
     generate_inv        : true
-    
+    use_instance_name   : false  # use short (platform) instead of instance name by default
+
 ```
 ## idempotency test
 If you want to check your code is idempotent you can use the idempotency_test. Essentially, this will run Ansible twice and check nothing changed in the next run. If something changed it will list the tasks. Note: If your using Ansible callback in your config this might conflict.

--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module AnsiblePush
-    VERSION = "0.3.9"
+    VERSION = "0.3.11"
   end
 end

--- a/lib/kitchen/provisioner/ansible_push.rb
+++ b/lib/kitchen/provisioner/ansible_push.rb
@@ -40,6 +40,7 @@ module Kitchen
       default_config :raw_arguments, nil
       default_config :idempotency_test, false
       default_config :fail_non_idempotent, true
+      default_config :use_instance_name, false
 
       # For tests disable if not needed
       default_config :chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"
@@ -88,7 +89,11 @@ module Kitchen
 
       def machine_name
         return @machine_name if defined? @machine_name
-        @machine_name = instance.name.gsub(/[<>]/, '').split("-").drop(1).join("-")
+        unless config[:use_instance_name]
+          @machine_name = instance.platform.name.gsub(/[<>]/, '')
+        else
+          @machine_name = instance.name.gsub(/[<>]/, '')
+        end
         debug("machine_name=" + @machine_name.to_s)
         @machine_name
       end

--- a/lib/kitchen/provisioner/ansible_push.rb
+++ b/lib/kitchen/provisioner/ansible_push.rb
@@ -90,7 +90,7 @@ module Kitchen
       def machine_name
         return @machine_name if defined? @machine_name
         unless config[:use_instance_name]
-          @machine_name = instance.platform.name.gsub(/[<>]/, '')
+          @machine_name = instance.name.gsub(/[<>]/, '').split("-").drop(1).join("-")
         else
           @machine_name = instance.name.gsub(/[<>]/, '')
         end


### PR DESCRIPTION
This PR adds the use_instance_name flag.

The flag is set to false by default which sets the machine name to the platform name (the originally intended behavior). If set to true, the machine name is set to the instance name (suite+platform)
