### PR TITLE
supports windows os which built by kitchen-ec2

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ transport:
 provisioner:
     name                  : ansible_push
     chef_bootstrap_url    : nil
+    ansible_port          : 5586
     ansible_connection    : "winrm"
 ...
 ```

--- a/lib/kitchen-ansible/util_inventory.rb
+++ b/lib/kitchen-ansible/util_inventory.rb
@@ -8,12 +8,13 @@ def write_var_to_yaml(yaml_file, hash_var)
   end
 end
 
-def generate_instance_inventory(name, host, mygroup, instance_connection_option, ansible_connection)
+def generate_instance_inventory(name, host, mygroup, instance_connection_option, ansible_connection, ansible_port)
   unless instance_connection_option.nil?
     port = instance_connection_option[:port]
     keys = instance_connection_option[:keys]
     user = instance_connection_option[:user]
-    pass = instance_connection_option[:pass]
+    pass = instance_connection_option[:pass] if instance_connection_option[:pass]
+    pass = instance_connection_option[:password] if instance_connection_option[:password]
   end
 
   temp_hash = {}
@@ -27,6 +28,8 @@ def generate_instance_inventory(name, host, mygroup, instance_connection_option,
   if ansible_connection == 'winrm'
     temp_hash['ansible_winrm_server_cert_validation'] = 'ignore'
     temp_hash['ansible_winrm_transport'] = 'ssl'
+    temp_hash['ansible_ssh_port'] = ansible_port if ansible_port
+    temp_hash['ansible_connection'] = 'winrm'
   end
   { name => temp_hash }
 end

--- a/lib/kitchen-ansible/util_inventory.rb
+++ b/lib/kitchen-ansible/util_inventory.rb
@@ -8,7 +8,7 @@ def write_var_to_yaml(yaml_file, hash_var)
   end
 end
 
-def generate_instance_inventory(name, host, mygroup, instance_connection_option, ansible_connection, ansible_port)
+def generate_instance_inventory(name, host, mygroup, instance_connection_option, conf)
   unless instance_connection_option.nil?
     port = instance_connection_option[:port]
     keys = instance_connection_option[:keys]
@@ -24,11 +24,11 @@ def generate_instance_inventory(name, host, mygroup, instance_connection_option,
   temp_hash['ansible_ssh_user'] = user if user
   temp_hash['ansible_ssh_pass'] = pass if pass
   temp_hash['mygroup'] = mygroup if mygroup
+  temp_hash['ansible_ssh_port'] = conf[:ansible_port] if conf[:ansible_port]
   # Windows issue ignore SSL
-  if ansible_connection == 'winrm'
+  if conf[:ansible_connection] == 'winrm'
     temp_hash['ansible_winrm_server_cert_validation'] = 'ignore'
     temp_hash['ansible_winrm_transport'] = 'ssl'
-    temp_hash['ansible_ssh_port'] = ansible_port if ansible_port
     temp_hash['ansible_connection'] = 'winrm'
   end
   { name => temp_hash }

--- a/lib/kitchen/provisioner/ansible_push.rb
+++ b/lib/kitchen/provisioner/ansible_push.rb
@@ -10,7 +10,7 @@ require 'kitchen-ansible/idempotancy'
 module Kitchen
   class Busser
     def non_suite_dirs
-      %w({data})
+      %w[{data}]
     end
   end
 
@@ -107,6 +107,7 @@ module Kitchen
         temp_options = []
         raise UserError, '"sudo" and "become" are mutually_exclusive' if conf[:sudo] && conf[:become]
         temp_options << '--become' if conf[:sudo] || conf[:become]
+
         raise UserError, '"sudo_user" and "become_user" are mutually_exclusive' if conf[:sudo_user] && conf[:become_user]
         if conf[:sudo_user]
           temp_options << "--become-user=#{conf[:sudo_user]}"
@@ -117,7 +118,6 @@ module Kitchen
         temp_options << "--become-method=#{conf[:become_method]}" if conf[:become_method]
         temp_options << '--ask-sudo-pass' if conf[:ask_sudo_pass]
         temp_options
-
       end
 
       def options
@@ -249,7 +249,7 @@ module Kitchen
         end
         debug("hostname='#{hostname}'")
         # Generate hosts
-        hosts = generate_instance_inventory(machine_name, hostname, conf[:mygroup], instance_connection_option, conf[:ansible_connection], conf[:ansible_port])
+        hosts = generate_instance_inventory(machine_name, hostname, conf[:mygroup], instance_connection_option, conf)
         write_var_to_yaml("#{TEMP_INV_DIR}/ansiblepush_host_#{machine_name}.yml", hosts)
         # Generate groups (if defined)
         write_var_to_yaml(TEMP_GROUP_FILE, conf[:groups]) if conf[:groups]

--- a/lib/kitchen/provisioner/ansible_push.rb
+++ b/lib/kitchen/provisioner/ansible_push.rb
@@ -107,7 +107,6 @@ module Kitchen
         temp_options = []
         raise UserError, '"sudo" and "become" are mutually_exclusive' if conf[:sudo] && conf[:become]
         temp_options << '--become' if conf[:sudo] || conf[:become]
-
         raise UserError, '"sudo_user" and "become_user" are mutually_exclusive' if conf[:sudo_user] && conf[:become_user]
         if conf[:sudo_user]
           temp_options << "--become-user=#{conf[:sudo_user]}"
@@ -118,6 +117,7 @@ module Kitchen
         temp_options << "--become-method=#{conf[:become_method]}" if conf[:become_method]
         temp_options << '--ask-sudo-pass' if conf[:ask_sudo_pass]
         temp_options
+
       end
 
       def options

--- a/lib/kitchen/provisioner/ansible_push.rb
+++ b/lib/kitchen/provisioner/ansible_push.rb
@@ -249,7 +249,7 @@ module Kitchen
         end
         debug("hostname='#{hostname}'")
         # Generate hosts
-        hosts = generate_instance_inventory(machine_name, hostname, conf[:mygroup], instance_connection_option, conf[:ansible_connection])
+        hosts = generate_instance_inventory(machine_name, hostname, conf[:mygroup], instance_connection_option, conf[:ansible_connection], conf[:ansible_port])
         write_var_to_yaml("#{TEMP_INV_DIR}/ansiblepush_host_#{machine_name}.yml", hosts)
         # Generate groups (if defined)
         write_var_to_yaml(TEMP_GROUP_FILE, conf[:groups]) if conf[:groups]


### PR DESCRIPTION
This PR solves following problems. By these problems, ansiblepush don't connect to windows server which built by kitchen-ec2.

1. The password of windows(`ansible_ssh_pass`) is not included in ansiblepush_host_#{machine_name}.yml.
1. The number of port(`ansible_ssh_port`) which uses to connect by winrm is not included in ansiblepush_host_#{machine_name}.yml.
1. `ansible_connection: winrm` is not included ansiblepush_host_#{machine_name}.yml.