### PR TITLE
Add `environment_vars` config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kitchen-ansiblepush (0.9.1)
+    kitchen-ansiblepush (0.10.0)
       test-kitchen (~> 1.4)
 
 GEM
@@ -91,4 +91,4 @@ DEPENDENCIES
   test-kitchen
 
 BUNDLED WITH
-   1.16.0
+   1.17.1

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ provisioner         :
 
     ## When running on EC2 with Windows and using get-password pass the password as ansible_password variable
     pass_transport_password: false
+    ## (optional), if you want to set specific environment variables when running ansible
+    environment_vars:
+	PROXMOX_URL: https://example.com:8006
 ```
 ## Idempotency test
 If you want to check your code is idempotent you can use the idempotency_test. Essentially, this will run Ansible twice and check nothing changed in the second run. If something changed it will list the tasks. Note: If your using Ansible callback in your config this might conflict.

--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module AnsiblePush
-    VERSION = '0.9.1'.freeze
+    VERSION = '0.10.0'.freeze
   end
 end

--- a/lib/kitchen/provisioner/ansible_push.rb
+++ b/lib/kitchen/provisioner/ansible_push.rb
@@ -56,6 +56,7 @@ module Kitchen
       default_config :ssh_common_args, nil
       default_config :module_path, nil
       default_config :pass_transport_password, false
+      default_config :environment_vars, {}
 
       # For tests disable if not needed
       default_config :chef_bootstrap_url, 'https://omnitruck.chef.io/install.sh'
@@ -88,6 +89,12 @@ module Kitchen
 
           raise UserError, "ansible extra_vars is in valid type: #{config[:extra_vars].class} value: #{config[:extra_vars]}" unless extra_vars_is_valid
         end
+
+        unless config[:environment_vars].is_a?(Hash)
+          raise UserError,
+                "ansible environment_vars is not a `Hash` type. Given type: #{config[:environment_vars].class}"
+        end
+
         info('Ansible push config validated')
         @validated_config = config
       end
@@ -176,6 +183,11 @@ module Kitchen
           'ANSIBLE_HOST_KEY_CHECKING' => conf[:host_key_checking].to_s
         }
         @command_env['ANSIBLE_CONFIG'] = conf[:ansible_config] if conf[:ansible_config]
+
+        # NOTE: Manually merge to fix keys possibly being Symbol(s)
+        conf[:environment_vars].each do |key, value|
+          @command_env[key.to_s] = value
+        end
         @command_env
       end
 


### PR DESCRIPTION
Adds `environment_vars` config.

# Why

This is very much needed when using an inventory source script such as `ec2.py`, `proxmox.py` and similar since you have to pass your authentication credentials via environment variables and/or files. Files are obviously not sufficient enough for dynamic test suites.


# So with this change usage is

```
provisioner:
  name: ansible_push
  extra_vars:
    FOO: bar
```

# Anything other  than a `Hash` will be marked as invalid configuration. E.g

```
provisioner:
  name: ansible_push
  extra_vars: []
```

# Also changed

Bumped version to minor version `0.10.0`, since we're introducing new functionality.

@ahelal 
