### PR TITLE
feature: allow passing transport password

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ provisioner         :
     generate_inv        : true
     use_instance_name   : false  # use short (platform) instead of instance name by default
     idempotency_test    : false
+
+    ## When running on EC2 with Windows and using get-password pass the password as ansible_password variable
+    pass_transport_password: false
 ```
 ## Idempotency test
 If you want to check your code is idempotent you can use the idempotency_test. Essentially, this will run Ansible twice and check nothing changed in the second run. If something changed it will list the tasks. Note: If your using Ansible callback in your config this might conflict.
@@ -123,6 +126,16 @@ provisioner:
     ansible_port          : 5586
     ansible_connection    : "winrm"
 ...
+```
+
+### Windows AWS EC2 support
+
+When running EC2 instance without password set via _get_password_ password can be passed from transport to Ansible command line as varaible:
+
+```yaml
+provisioner:
+    name:                       ansible_push
+    pass_transport_password:    true
 ```
 
 ## Pattern of usage

--- a/lib/kitchen/provisioner/ansible_push.rb
+++ b/lib/kitchen/provisioner/ansible_push.rb
@@ -55,6 +55,7 @@ module Kitchen
       default_config :ssh_extra_args, nil
       default_config :ssh_common_args, nil
       default_config :module_path, nil
+      default_config :pass_transport_password, false
 
       # For tests disable if not needed
       default_config :chef_bootstrap_url, 'https://omnitruck.chef.io/install.sh'
@@ -119,6 +120,10 @@ module Kitchen
         temp_options << "--user=#{conf[:remote_user]}" if remote_user
         temp_options << "--become-method=#{conf[:become_method]}" if conf[:become_method]
         temp_options << '--ask-sudo-pass' if conf[:ask_sudo_pass]
+
+        # if running on windows in ec2 and password is obtained via get-password
+        temp_options << "-e ansible_password='#{instance.transport.instance_variable_get(:@connection_options)[:password]}'" if conf[:pass_transport_password]
+
         temp_options
       end
 

--- a/spec/kitchen/provisioner/ansible_push_options_spec.rb
+++ b/spec/kitchen/provisioner/ansible_push_options_spec.rb
@@ -42,6 +42,62 @@ describe 'Options' do
     end
   end
 
+  context 'pass password enabled' do
+    let(:config) do
+      {
+        test_base_path: '/b',
+        kitchen_root: '/r',
+        log_level: :info,
+        playbook: 'spec/assets/ansible_test.yml',
+        generate_inv: false,
+        remote_user: 'test2',
+        become: true,
+        become_user: 'kitchen2',
+        become_method: 'sudo',
+        diff: true,
+        private_key: '/tmp/rsa_key',
+        ask_vault_pass: true,
+        start_at_task: 'c1',
+        raw_arguments: '-raw',
+        timeout: 10,
+        force_handlers: true,
+        step: true,
+        module_path: '/xxx',
+        scp_extra_args: 'x',
+        sftp_extra_args: 'y',
+        ssh_common_args: 'z',
+        ssh_extra_args: 'r',
+        pass_transport_password: true
+        # skip_tags: 'b1',
+        # verbose: "vvvv",
+        # ansible_connection: 'smart',
+        # extra_vars:
+        # groups: ""
+        # vault_password_file: '/tmp/vaut.key',
+      }
+    end
+
+    let(:provisioner) do
+      Kitchen::Provisioner::AnsiblePush.new(config).finalize_config!(instance)
+    end
+
+    let(:transport) do
+      class_double('Kitchen::Transport', name: 'hotbeans')
+    end
+
+    let(:instance) do
+      instance_double('Kitchen::Instance', name: 'coolbeans', transport: transport, logger: logger, suite: suite, platform: platform)
+    end
+
+    before do
+      allow(transport).to receive(:instance_variable_get).with(:@connection_options).and_return(password: 'mocked_password')
+    end
+
+    it 'password is as variable in cmdline' do
+      expect(provisioner.options).to include("-e ansible_password='mocked_password'")
+    end
+  end
+
   context 'all options' do
     let(:config) do
       {
@@ -73,6 +129,7 @@ describe 'Options' do
         # extra_vars:
         # groups: ""
         # vault_password_file: '/tmp/vaut.key',
+        # pass_transport_password: false
       }
     end
 


### PR DESCRIPTION
I do run Kitchen using `kitchen-ec2` and without any password/certificate pre-baked in the image as I am using AWS EC2 _get-password_ in pipelines.

This allow passing password from _transport_ (where it is fetched with instance key) to Ansible as:
`-e ansible_password='password_from_transport'`

Another option would be having static key and it's private part visible from CI and use some hook, this seems as an elegant way.