### PR TITLE
Add `playbooks` to specify multiple playbooks to run

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,6 @@ Metrics/CyclomaticComplexity:
 # Offense count: 3
 Metrics/PerceivedComplexity:
   Max: 30
+
+Metrics/ClassLength:
+  Max: 260

--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ gem install kitchen-ansiblepush-<version>.gem
 provisioner         :
     ## required options
     name                : ansible_push
+    ## Either `playbook` or `playbooks` is required
     playbook            : "../../plays/web.yml"     # Path to Play yaml
+    playbooks           :
+	- "../../plays/database.yml" # Path to database play yaml
+	- "../../plays/web.yml"      # Path to web play yaml
     ##
     ## Optional  argument
     ansible_config      : "/path/to/ansible/ansible.cfg" # path to ansible config file

--- a/lib/kitchen-ansible/idempotancy.rb
+++ b/lib/kitchen-ansible/idempotancy.rb
@@ -2,13 +2,21 @@ require 'securerandom'
 
 def idempotency_test
   info('*************** idempotency test ***************')
+  conf[:playbooks].each do |playbook|
+    _idempotency_test_single(playbook)
+  end
+end
+
+def _idempotency_test_single(playbook)
   file_path = "/tmp/kitchen_ansible_callback/#{SecureRandom.uuid}.changes"
   exec_ansible_command(
     command_env.merge(
       'ANSIBLE_CALLBACK_PLUGINS'   => "#{File.dirname(__FILE__)}/../../callback/",
       'ANSIBLE_CALLBACK_WHITELIST' => 'changes',
       'PLUGIN_CHANGES_FILE'        => file_path
-    ), command, 'ansible-playbook'
+    ),
+    command(playbook),
+    'ansible-playbook'
   )
   debug("idempotency file #{file_path}")
   # Check ansible callback if changes has occured in the second run

--- a/spec/kitchen/provisioner/ansible_push_spec.rb
+++ b/spec/kitchen/provisioner/ansible_push_spec.rb
@@ -24,7 +24,14 @@ describe Kitchen::Provisioner::AnsiblePush do
   end
 
   let(:instance) do
-    instance_double('Kitchen::Instance', name: 'coolbeans', logger: logger, suite: suite, platform: platform)
+    double = instance_double(
+      'Kitchen::Instance',
+      name: 'coolbeans',
+      logger: logger,
+      suite: suite,
+      platform: platform
+    )
+    double
   end
 
   # let(:machine_name) do
@@ -39,11 +46,11 @@ describe Kitchen::Provisioner::AnsiblePush do
     expect(provisioner.diagnose_plugin[:api_version]).to eq(2)
   end
 
-  it 'Should fail with no playbook file' do
+  it "fails with no 'playbook' and 'playbooks' specified" do
     expect { provisioner.prepare_command }.to raise_error(Kitchen::UserError)
   end
 
-  describe 'Baisc config' do
+  describe 'Basic config' do
     let(:config) do
       {
         test_base_path: '/b',


### PR DESCRIPTION
Adds `playbooks` config. 

# Why

When running "complex" playbook provisioning scenarios before testing, you may need to re-use different playbooks.

For example I was testing playbooks.

However for the release process provisioning from scratch you execute e.g playbook `db.yml` and `web.yml`.

They're separate and if I was to create a new playbook that includes both roles used, I wouldn't test the actual playbooks executed.

# So with this change usage is

```
provisioner:
  name: ansible_push
  playbooks:
    - db.yml
    - web.yml
```

# Anything other  than an `Array` will be marked as invalid configuration. E.g

```
provisioner:
  name: ansible_push
  playbooks: {}
```

# Important

Includes #51 

@ahelal 
