### PR TITLE
Add ansible host and user in inventory for Windows builds

### DIFF
--- a/lib/kitchen-ansible/util_inventory.rb
+++ b/lib/kitchen-ansible/util_inventory.rb
@@ -30,6 +30,8 @@ def generate_instance_inventory(name, host, mygroup, instance_connection_option,
     temp_hash['ansible_winrm_server_cert_validation'] = 'ignore'
     temp_hash['ansible_winrm_transport'] = 'ssl'
     temp_hash['ansible_connection'] = 'winrm'
+    temp_hash['ansible_host'] = temp_hash['ansible_ssh_host']
+    temp_hash['ansible_user'] = temp_hash['ansible_ssh_user']
   end
   { name => temp_hash }
 end


### PR DESCRIPTION
`ansible_host` and `ansible_user` are needed when running test kitchen for against Windows machines.