### PR TITLE
Fix multiple issues

### DIFF
--- a/lib/kitchen-ansible/print_inventory_cli.rb
+++ b/lib/kitchen-ansible/print_inventory_cli.rb
@@ -5,10 +5,11 @@ require 'kitchen-ansible/util_inventory.rb'
 
 class PrintInventory
   def initialize
+    temp_group_path = File.join(TEMP_INV_DIR, ENV["INSTANCE_NAME"], TEMP_GROUP_FILE)
     @inventory = {}
     @all = []
-    @groups = if File.exist?(TEMP_GROUP_FILE)
-                read_from_yaml TEMP_GROUP_FILE
+    @groups = if File.exist?(temp_group_path)
+                read_from_yaml temp_group_path
               else
                 {}
               end
@@ -20,7 +21,7 @@ class PrintInventory
   end
 
   def read_all_hosts
-    Dir.glob(TEMP_INV_DIR + '/ansiblepush_host_*.yml')
+    Dir.glob(File.join(TEMP_INV_DIR, ENV["INSTANCE_NAME"], 'ansiblepush_host_*.yml'))
   end
 
   def construct

--- a/lib/kitchen-ansible/util_inventory.rb
+++ b/lib/kitchen-ansible/util_inventory.rb
@@ -18,6 +18,7 @@ def generate_instance_inventory(name, host, mygroup, instance_connection_option,
   end
 
   temp_hash = {}
+  temp_hash['ansible_host'] = host
   temp_hash['ansible_ssh_host'] = host
   temp_hash['ansible_ssh_port'] = port if port
   temp_hash['ansible_ssh_private_key_file'] = keys[0] if keys
@@ -30,7 +31,6 @@ def generate_instance_inventory(name, host, mygroup, instance_connection_option,
     temp_hash['ansible_winrm_server_cert_validation'] = 'ignore'
     temp_hash['ansible_winrm_transport'] = 'ssl'
     temp_hash['ansible_connection'] = 'winrm'
-    temp_hash['ansible_host'] = temp_hash['ansible_ssh_host']
     temp_hash['ansible_user'] = temp_hash['ansible_ssh_user']
   end
   { name => temp_hash }

--- a/lib/kitchen-ansible/util_inventory.rb
+++ b/lib/kitchen-ansible/util_inventory.rb
@@ -1,8 +1,11 @@
+require 'fileutils'
+
 TEMP_INV_DIR = '.kitchen/ansiblepush'.freeze
-TEMP_GROUP_FILE = "#{TEMP_INV_DIR}/ansiblepush_groups_inventory.yml".freeze
+TEMP_GROUP_FILE = "ansiblepush_groups_inventory.yml".freeze
 
 def write_var_to_yaml(yaml_file, hash_var)
-  Dir.mkdir TEMP_INV_DIR unless File.exist?(TEMP_INV_DIR)
+  base_path = File.dirname(yaml_file)
+  FileUtils.mkdir_p base_path unless File.exist?(base_path)
   File.open(yaml_file, 'w') do |file|
     file.write hash_var.to_yaml
   end

--- a/lib/kitchen/provisioner/ansible_push.rb
+++ b/lib/kitchen/provisioner/ansible_push.rb
@@ -243,8 +243,8 @@ module Kitchen
 
       def exec_ansible_command(env, command, desc)
         debug("env=#{env} command=#{command}")
-        system(env, command.to_s)
-        exit_code = $CHILD_STATUS.exitstatus
+        stdout_and_stderr, exit_code = Open3.capture2e(env, command.to_s)
+        info(stdout_and_stderr)
         debug("ansible-playbook exit code = #{exit_code}")
         raise UserError, "#{desc} returned a non zero #{exit_code}. Please see the output above." if exit_code.to_i != 0
       end

--- a/lib/kitchen/provisioner/ansible_push.rb
+++ b/lib/kitchen/provisioner/ansible_push.rb
@@ -240,7 +240,7 @@ module Kitchen
         debug("env=#{env} command=#{command}")
         Open3.popen2e(env, command.to_s) do |stdin, stdout_and_stderr, status_thread|
           stdout_and_stderr.each_line do |line|
-            info(line)
+            info("[#{instance.name}]#{line}")
           end
           exit_code = status_thread.value
           debug("ansible-playbook exit code = #{exit_code}")

--- a/lib/kitchen/provisioner/ansible_push.rb
+++ b/lib/kitchen/provisioner/ansible_push.rb
@@ -238,10 +238,14 @@ module Kitchen
 
       def exec_ansible_command(env, command, desc)
         debug("env=#{env} command=#{command}")
-        stdout_and_stderr, exit_code = Open3.capture2e(env, command.to_s)
-        info(stdout_and_stderr)
-        debug("ansible-playbook exit code = #{exit_code}")
-        raise UserError, "#{desc} returned a non zero #{exit_code}. Please see the output above." if exit_code.to_i != 0
+        Open3.popen2e(env, command.to_s) do |stdin, stdout_and_stderr, status_thread|
+          stdout_and_stderr.each_line do |line|
+            info(line)
+          end
+          exit_code = status_thread.value
+          debug("ansible-playbook exit code = #{exit_code}")
+          raise UserError, "#{desc} returned a non zero #{exit_code}. Please see the output above." if exit_code.to_i != 0
+        end
       end
 
       def instance_connection_option

--- a/lib/kitchen/provisioner/ansible_push.rb
+++ b/lib/kitchen/provisioner/ansible_push.rb
@@ -180,7 +180,8 @@ module Kitchen
         @command_env = {
           'PYTHONUNBUFFERED' => '1', # Ensure Ansible output isn't buffered
           'ANSIBLE_FORCE_COLOR' => 'true',
-          'ANSIBLE_HOST_KEY_CHECKING' => conf[:host_key_checking].to_s
+          'ANSIBLE_HOST_KEY_CHECKING' => conf[:host_key_checking].to_s,
+          'INSTANCE_NAME' => instance.name.gsub(/[<>]/, '')
         }
         @command_env['ANSIBLE_CONFIG'] = conf[:ansible_config] if conf[:ansible_config]
 
@@ -269,9 +270,9 @@ module Kitchen
         debug("hostname='#{hostname}'")
         # Generate hosts
         hosts = generate_instance_inventory(machine_name, hostname, conf[:mygroup], instance_connection_option, conf)
-        write_var_to_yaml("#{TEMP_INV_DIR}/ansiblepush_host_#{machine_name}.yml", hosts)
+        write_var_to_yaml("#{TEMP_INV_DIR}/#{instance.name.gsub(/[<>]/, '')}/ansiblepush_host_#{machine_name}.yml", hosts)
         # Generate groups (if defined)
-        write_var_to_yaml(TEMP_GROUP_FILE, conf[:groups]) if conf[:groups]
+        write_var_to_yaml("#{TEMP_INV_DIR}/#{instance.name.gsub(/[<>]/, '')}/#{TEMP_GROUP_FILE}", conf[:groups]) if conf[:groups]
       end
 
       def extra_vars_argument

--- a/lib/kitchen/provisioner/ansible_push.rb
+++ b/lib/kitchen/provisioner/ansible_push.rb
@@ -148,12 +148,6 @@ module Kitchen
         options << "--start-at-task=#{conf[:start_at_task]}" if conf[:start_at_task]
         options << "--inventory-file=#{conf[:generate_inv_path]}" if conf[:generate_inv]
         options << verbosity_argument.to_s if conf[:verbose]
-        # By default we limit by the current machine,
-        options << if conf[:limit]
-                     "--limit=#{as_list_argument(conf[:limit])}"
-                   else
-                     "--limit=#{machine_name}"
-                   end
         options << "--timeout=#{conf[:timeout]}" if conf[:timeout]
         options << "--force-handlers=#{conf[:force_handlers]}" if conf[:force_handlers]
         options << "--step=#{conf[:step]}" if conf[:step]

--- a/spec/kitchen/kitchen-ansible/print_inventory_cli_spec.rb
+++ b/spec/kitchen/kitchen-ansible/print_inventory_cli_spec.rb
@@ -4,6 +4,7 @@ require 'kitchen-ansible/print_inventory_cli'
 
 describe PrintInventory do
   before :each do
+    ENV['INSTANCE_NAME'] = 'example_suite'
     @printinventory = PrintInventory.new
   end
 

--- a/spec/kitchen/provisioner/ansible_push_options_spec.rb
+++ b/spec/kitchen/provisioner/ansible_push_options_spec.rb
@@ -38,7 +38,7 @@ describe 'Options' do
 
     it 'match min' do
       expect(provisioner.options).to eq(['--become', '--become-user=kitchen',
-                                         '--user=test', '--limit='])
+                                         '--user=test'])
     end
   end
 
@@ -140,7 +140,7 @@ describe 'Options' do
     it 'match all' do
       expect(provisioner.options).to eq(['--become', '--become-user=kitchen2', '--user=test2', '--become-method=sudo',
                                          '--private-key=/tmp/rsa_key', '--diff', '--ask-vault-pass', '--start-at-task=c1',
-                                         '--limit=', '--timeout=10', '--force-handlers=true', '--step=true',
+                                         '--timeout=10', '--force-handlers=true', '--step=true',
                                          '--module-path=/xxx', '--scp-extra-args=x', '--sftp-extra-args=y', '--ssh-common-args=z',
                                          '--ssh-extra-args=r', '-raw'])
     end


### PR DESCRIPTION
Fixes the following  issues, one commit per issue

https://github.com/ahelal/kitchen-ansiblepush/issues/69
trivial

https://github.com/ahelal/kitchen-ansiblepush/issues/68
trivial 

https://github.com/ahelal/kitchen-ansiblepush/issues/70

ansiblepush encodes the inventory data for host and groups in yaml files (stores them in a static directory, same for all suites), then invokes ansible with a dynamic inventory script that parses them. As explained in the issue using the same dir causes conflicts.

I changed the behavior in that the yaml files are stored in a unique per kitchen suite subdirectory. The dynamic inventory script then reads the ENV var INSTANCE_NAME to know which subdir to read the yaml files from

https://github.com/ahelal/kitchen-ansiblepush/issues/71
trivial, but only possible because we fixed the previous issue